### PR TITLE
retrieve "forum_url" from the "mybb" config namespace rather than global...

### DIFF
--- a/application/views/forum/_news.php
+++ b/application/views/forum/_news.php
@@ -6,7 +6,7 @@
 	<div class="newsitem">
 	    <div class="date"><?= date('Y.m.d', $item['dateline']) ?></div>
 	    <p>
-		<a href="<?= config_item('forum_url') . '/thread-' . $item['tid'] . '.html' ?>">
+		<a href="<?= config_item('forum_url', 'mybb') . '/thread-' . $item['tid'] . '.html' ?>">
 		    <?= $item['subject'] ?>
 		</a>
 	    </p>


### PR DESCRIPTION
The "forum_url" value is not being retrieved from the "mybb" config namespace correctly. This should fix that, although I haven't tested this locally.
