### PR TITLE
update docs page and download page

### DIFF
--- a/application/views/docs.php
+++ b/application/views/docs.php
@@ -45,38 +45,27 @@ defined('BASEPATH') OR exit('No direct script access allowed');
  */
 ?>
 <div class="container">
-    <div class="row">
+	<div class="row">
 
 		<div class="col-md-12 col-sm-12 text-center title">
 			<span class="glyphicon glyphicon-book big-glyph"></span>
-			The primary documentation for CodeIgniter is its User Guide, included in the package downloads.<br>The User Guide can also be read online here
+			<p>The primary documentation for CodeIgniter is its User Guide, included in the package downloads.<br>
+			The User Guide can also be read online here</p>
 		</div>
 
 		<div class="col-md-6 col-sm-6">
 			<div class="bs-component">
 				<div class="well download">
 					<h3 class="text-center">CodeIgniter 3.x</h3>
-
-					CodeIgniter 3.x is the current version of the framework, under active development.<br><br>
-
-					Its User Guide contains an introduction, tutorial, a number 
-					of "how to" guides, and then reference documentation for 
-					the components that make up the framework.<br><br>
-
-					CodeIgniter 3.x is licensed under the 
-					<a href="/user_guide/license.html">MIT License</a>.
-					<br><br>
-					<strong>Note:</strong> The user guide linked to below is periodically rebuilt from the
-					"develop" branch of the project, and may address un-released features.
-					The user guide that corresponds exactly to the released framework is bundled
-					with the download.<br/><br/>
-					<a href="/user_guide" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-share"></span> View User Guide (3.x) online</a>
-					<a href="/data/CodeIgniter-3.0.2-userguide.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide (3.0.2) to read offline</a>
-					<!--<a href="/data/CodeIgniter3-userguide.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide (3.x) to read offline</a>
+					<p>CodeIgniter 3.x is the current version of the framework, under active development.</p>
+					<p>CodeIgniter 3.x is licensed under the 
+						<a href="/user_guide/license.html">MIT License</a>.</p>
+					<a href="/user_guide" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-share"></span> View latest User Guide online</a>
+					<a href="/data/CodeIgniter-3.0.2-userguide.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the latest User Guide to read offline</a>
+<!-- 					<a href="/data/CodeIgniter3-userguide.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide (3.x) to read offline</a>
 					<a href="/data/CodeIgniter3-userguide-epub.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide in epub format</a>
-					-->
-					The zipped and epub "develop" user guide have been temporarily removed. We are working on a script to produce an "official"
-					epub version of the relesed user guide :)
+ -->
+ 					
 				</div>
 			</div>
 		</div>
@@ -85,18 +74,37 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 			<div class="bs-component">
 				<div class="well download">
 					<h3 class="text-center">CodeIgniter 2.x</h3>
+					<p>CodeIgniter 2.x is the legacy version of the framework.</p>
+					<p>CodeIgniter 2.x is licensed under the  
+						<a href="/userguide2/license.html">EllisLab open source license</a>.</p>
+					<a href="/userguide2" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-share"></span> View latest User Guide online</a>
+					<a href="/data/CodeIgniter2-stable-user_guide.zip" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-save"></span> Download the latest User Guide to read offline</a>
+				</div>
+			</div>
+		</div>
 
-					CodeIgniter 2.x is the legacy version of the framework.<br><br>
-
-					Its User Guide contains an introduction, tutorial, a number
+		<div class="col-md-12 col-sm-12">
+			<div class="bs-component">
+				<div class="well download">
+					<h3>Notes</h3>
+					<div class="list-group">
+						<div class="list-group-item">
+							<h4 class="list-group-item-heading">What's inside User Guide?</h4>
+							<p class="list-group-item-text">The User Guide contains an introduction, tutorial, a number
 					of "how to" guides, and then reference documentation 
-					for the components that make up the framework.<br><br>
+					for the components that make up the framework.</p>
+						</div>
+						<div class="list-group-item">
+							<h4 class="list-group-item-heading">Where else can I find User Guide?</h4>
+							<p class="list-group-item-text">The user guide download is simply the zipped folder from the released version.
+					It is included in the <a href="/download">framework download</a>.</p>
+						</div>
+						<div class="list-group-item">
+							<h4 class="list-group-item-heading">Epub Version</h4>
+							<p class="list-group-item-text">The epub user guide have been temporarily removed. We are working on a script to produce an "official" epub version of the relesed user guide :)</p>
+						</div>
+					</div>
 
-					CodeIgniter 2.x is licensed under the  
-					<a href="/userguide2/license.html">EllisLab open source license</a>.
-					<br><br>
-					<a href="/userguide2" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-share"></span> View User Guide  (2.x) online</a>
-					<a href="/data/CodeIgniter2-stable-user_guide.zip" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide  (2.x) to read offline</a>
 				</div>
 			</div>
 		</div>

--- a/application/views/download.php
+++ b/application/views/download.php
@@ -46,7 +46,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 ?>
 <div class="container">
 
-    <div class="row">
+	<div class="row">
 
 		<div class="col-md-12 col-sm-12 text-center title">
 			<span class="glyphicon glyphicon-download big-glyph"></span>
@@ -61,8 +61,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 					CodeIgniter 3.0.2 is the current version of the framework.<br><br>
 					There have been a number of refinements since version 2.x, notably with
 					the database, session handling and encryption. Development of this version is ongoing.<br><br>
-					<strong>Note:</strong> The user guide download below is simply the zipped folder from the released version.
-					It is included in the framework download.<br><br>
+					
 					<a href="https://github.com/bcit-ci/CodeIgniter" class="btn btn-warning btn-block"><span class="glyphicons glyphicons-link"></span>View Code On Github</a>
 					<a href="https://github.com/bcit-ci/CodeIgniter/archive/3.0.2.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download Codeigniter 3.0.2</a>
 					<!--<a href="/data/CodeIgniter-3.0.1-userguide.zip" class="btn btn-warning btn-block"><span class="glyphicon glyphicon-save"></span> Download the User Guide (3.0.1) to read offline</a>
@@ -82,25 +81,25 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 					version (2.2.0) came out in July, 2014, and
 					the current version (2.2.5) came out in September, 2015.<br><br>
 					<a href="https://github.com/bcit-ci/CodeIgniter/tree/2.2-stable" class="btn btn-primary btn-block"><span class="glyphicons glyphicons-link"></span> View Code On Github</a>
-					<a href="https://github.com/bcit-ci/CodeIgniter/archive/2.2.5.zip" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-save"></span> Download Codeigniter 2.2.4</a>
+					<a href="https://github.com/bcit-ci/CodeIgniter/archive/2.2.5.zip" class="btn btn-primary btn-block"><span class="glyphicon glyphicon-save"></span> Download Codeigniter 2.2.5</a>
 				</div>
 			</div>
 		</div>
 
 		<!--
 		<div class="col-md-6 col-sm-6">
-	   <div class="bs-component">
-	  <div class="well download">
-	 <h3 class="text-center">CodeIgniter 4?</h3>
+			<div class="bs-component">
+				<div class="well download">
+					<h3 class="text-center">CodeIgniter 4?</h3>
 	 
-	 CodeIgniter 4 is the upcoming version of the framework.<br><br>
-	 We have been discussing it on our forum, and recently released
-	 a proposed roadmap. Development is just getting underway,
-	 and links will be posted here once there is something you
-	 can kick the tires of!<br><br>
-	 <a href="http://forum.codeigniter.com/forum-27.html" class="btn btn-success btn-block"><span class="glyphicons glyphicons-link"></span> Join the discussion on our forum!</a>
-	  </div>
-	   </div>
+					CodeIgniter 4 is the upcoming version of the framework.<br><br>
+					We have been discussing it on our forum, and recently released
+					a proposed roadmap. Development is just getting underway,
+					and links will be posted here once there is something you
+					can kick the tires of!<br><br>
+	 				<a href="http://forum.codeigniter.com/forum-27.html" class="btn btn-success btn-block"><span class="glyphicons glyphicons-link"></span> Join the discussion on our forum!</a>
+	  			</div>
+	   		</div>
 		</div>
 		-->
 


### PR DESCRIPTION
I updated docs page to make the information more accurate since we do not provide "develop" version actually. The main change is to update the out-dated information. Some other improvements are included as well. 

##### changes in doc page
- delete message of develop version
- add a "Note" block below: because some of the messages are common to both versions, I think we should host a place for the common messages rather than repeat them. I am not sure if this is what we want. I can revert the changes if you feel this is not necessary.
- add `<p>` wrapper to the text: currently, messages are not wrapped, which means we can not control the margin, styles, paddings easily. I suggest we add `<p>` wrapper to them. The other benefit of using `<p>` is that we do not have to use `<br>` everywhere. I can update others as well if you agree with me :)
- fix indentation level

##### changes in download page
- move the user guide description to the doc page. There is not user guide download "below".
- the version number should be 2.2.5, right?
- fix indentation level