### PR TITLE
add responsive support to git contribution

### DIFF
--- a/application/views/contribute.php
+++ b/application/views/contribute.php
@@ -166,17 +166,19 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 		<!-- Acknowledge contributors -->
 		<div class="col-md-12 col-sm-12">
-			<h3>Acknowledging Our Top Framework Contributors</h3>
-			<p>{fw_heros}</p>
+			<div class="bs-component">
+				<div class="well download">
+					<h3>Acknowledging Our Top Framework Contributors</h3>
+					<div class="row">{fw_heros}</div>
+					<hr/>
+					<h3>Acknowledging Our Top Website Contributors</h3>
+					<div class="row">{web_heros}</div>
+					<hr/>
+					<h3>Acknowledging Our Top Translation Contributors</h3>
+					<div class="row">{trans_heros}</div>
+				</div>
+			</div>
 		</div>
-		<div class="col-md-12 col-sm-12">
-			<h3>Acknowledging Our Top Website Contributors</h3>
-			<p>{web_heros}</p>
-		</div>		
-		<div class="col-md-12 col-sm-12">
-			<h3>Acknowledging Our Top Translation Contributors</h3>
-			<p>{trans_heros}</p>
-		</div>		
 
 		<div class="col-md-12 col-sm-12">
 			<div class="bs-component">

--- a/application/views/theme/_heros.php
+++ b/application/views/theme/_heros.php
@@ -1,7 +1,7 @@
 {heros}
-<div class="col-md-1">
+<div class="col-xs-3 col-sm-2 col-md-1">
 	<a href="{url}" target="_blank">
-		<img src="{avatar}" width="64" height="64" title="{name}"/></a>
-	<p class="text-center">{stars}</p>
+		<img class="img-responsive img-rounded center-block" src="{avatar}" width="64" height="64" title="{name}"/></a>
+	<p class="text-center row">{stars}</p>
 </div>
 {/heros}


### PR DESCRIPTION
I just noticed that github contributions are acknowledged on the official website and I feel proud to be listed. :)

This change is intended to add mobile supports for it:
- make images responsive and centered
- add class "col-xs-3 col-sm-2" to avoid simple stack on smaller devices
- add "wells" to give it an inset effect to be consistent(not necessary)

Signed-off-by: Hongyi Zhang <hongyi73.zhang@gmail.com>