### PR TITLE
change button to primary in community page

### DIFF
--- a/application/views/community.php
+++ b/application/views/community.php
@@ -101,7 +101,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 						If you are new to IRC, read this 
 						<a href="http://workaround.org/getting-help-on-irc" target="_blank">introduction</a> 
 						first.</p>
-					<a class="btn btn-primary btn-block" href="http://webchat.freenode.net/?channels=%23codeigniter&uio=d4%22" target="_blank">
+					<a class="btn btn-info btn-block" href="http://webchat.freenode.net/?channels=%23codeigniter&uio=d4%22" target="_blank">
 						<span class="glyphicon glyphicon-share"></span> Visit I.R.C.</a>
 				</div>
 			</div>
@@ -121,7 +121,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 					<p>Github issues are also used for tracking planned and approved enhancements,
 						often tied in to specific releases.</p>
 					<br/>
-					<a class="btn btn-primary btn-block" href="https://github.com/bcit-ci/CodeIgniter/"><span class="glyphicon glyphicon-share"></span> Visit Github</a>
+					<a class="btn btn-info btn-block" href="https://github.com/bcit-ci/CodeIgniter/"><span class="glyphicon glyphicon-share"></span> Visit Github</a>
 				</div>
 			</div>
 		</div>

--- a/application/views/community.php
+++ b/application/views/community.php
@@ -101,7 +101,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 						If you are new to IRC, read this 
 						<a href="http://workaround.org/getting-help-on-irc" target="_blank">introduction</a> 
 						first.</p>
-					<a class="btn btn-default btn-block" href="http://webchat.freenode.net/?channels=%23codeigniter&uio=d4%22" target="_blank">
+					<a class="btn btn-primary btn-block" href="http://webchat.freenode.net/?channels=%23codeigniter&uio=d4%22" target="_blank">
 						<span class="glyphicon glyphicon-share"></span> Visit I.R.C.</a>
 				</div>
 			</div>
@@ -121,7 +121,7 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 					<p>Github issues are also used for tracking planned and approved enhancements,
 						often tied in to specific releases.</p>
 					<br/>
-					<a class="btn btn-default btn-block" href="https://github.com/bcit-ci/CodeIgniter/"><span class="glyphicon glyphicon-share"></span> Visit Github</a>
+					<a class="btn btn-primary btn-block" href="https://github.com/bcit-ci/CodeIgniter/"><span class="glyphicon glyphicon-share"></span> Visit Github</a>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
I wonder if there is some special reason that the button types are inconsistent in community page. Visit Forum button is orange and Github and IRC buttons are grey. If this is not due the special design, I would propose to change the default type to primary so that the colors would be consistent. A grey button look like disabled to me...